### PR TITLE
Link to Github and dockerhub

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,20 @@
 ---
 ---
+
 <h1>Errbit</h1>
 
 <h2>The open source, self-hosted error catcher</h2>
 
-Errbit is a tool for collecting and managing errors from other applications. It
-is Airbrake API compliant, so if you are already using Airbrake, you can just
-point the airbrake gem to your Errbit server.
+<p>
+  Errbit is a tool for collecting and managing errors from other applications.
+  It is Airbrake API compliant, so if you are already using Airbrake, you can
+  just point the airbrake gem to your Errbit server.
+</p>
+<p>
+  Documentation is available for all released versions of Errbit and master. It
+  is built directly from whatever documentation was available in the ./docs
+  folder at the time of release.
+</p>
 
-Documentation is available for all released versions of Errbit and master. It
-is built directly from whatever documentation was available in the ./docs
-folder at the time of release.
+<a href="https://github.com/errbit/errbit">GitHub</a> |
+<a href="https://hub.docker.com/r/errbit/errbit/">Docker Hub</a>


### PR DESCRIPTION
Errbit's github and docker images are the 2 most useful errbit links in
my opinion and they weren't on errbit's homepage.